### PR TITLE
fix compilation on linux

### DIFF
--- a/src/TsicSensor.h
+++ b/src/TsicSensor.h
@@ -10,7 +10,7 @@
 #define TSIC_Sensor_h
 
 #include "Arduino.h"
-#include "data\TsicData.h"
+#include "data/TsicData.h"
 
 enum class TsicScale : byte{
    Celsius = 0,


### PR DESCRIPTION
forward slash is the right c/c++ path separator... with backslash it failed compiling for me.

(see https://stackoverflow.com/questions/5790161/is-the-backslash-acceptable-in-c-and-c-include-directives)

p.s.: apparently git decided to change the line-endings in this file, sorry for that.
